### PR TITLE
Implemented /whois command that shows users public keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Current status
 | USER      | done     |                                                            |
 | MODE      | done     | Always returns mode `+nsv`                                 |
 | CAP       | done     | Always returns empty list                                  |
-| WHOIS     | todo     |                                                            |
+| WHOIS     | done     | TODO: can be improved with idle-time and signon-timestamp  |
 | add more  | todo     | Is there other IRC commands worth to translate to cabal?   |
 
 


### PR DESCRIPTION
Also fixed a bug in the otherwise quite broken test-spec.
Irc-communication tests now communicate over tcp-port: 30000 + random*1000
to avoid accidentally connecting to any existing irc-cabal bouncer you might have running in the background.