### PR TITLE
Bugfix X-Chat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Current status
 | MODE      | done     | Always returns mode `+nsv`                                 |
 | CAP       | done     | Always returns empty list                                  |
 | WHOIS     | done     | TODO: can be improved with idle-time and signon-timestamp  |
+| WHO       | todo     | missing                                                    |
 | add more  | todo     | Is there other IRC commands worth to translate to cabal?   |
 
 

--- a/index.js
+++ b/index.js
@@ -527,7 +527,19 @@ class CabalIRC {
             return // XChat quits this way :S
           }
 
-          let cmd = message.command.toLowerCase()
+          let cmd
+
+          // Probably a bug in irc-protocol lib.
+          // for some reason, command ends up as the first parameter.
+          // Triggered using XChat when using commands like /whois, /join, /part
+          // this is a work-around to avoid crashing and 'try' to execute the command anyway.
+          if(typeof message.command === 'undefined' &&
+            typeof this[(message.parameters[0] || '').toLowerCase()] === 'function') {
+            cmd = message.parameters.shift().toLowerCase()
+          } else {
+            cmd = message.command.toLowerCase()
+          }
+
           // log(message)
           let fn = this[cmd]
           if (!fn) this.notImplemented(message)


### PR DESCRIPTION
For some reason; commands like /whois, /join, /part aren't parsed properly by irc-protocol,
This workaroud that attempts to use the first parameter as a command instead, to let X-Chat work happily
and avoid crash.